### PR TITLE
had to remove link query from primary nav item as no links currently …

### DIFF
--- a/src/queries/navItems.js
+++ b/src/queries/navItems.js
@@ -9,9 +9,6 @@ export const primaryNavItemsQuery = graphql`
                 label {
                     text
                 }
-                link {
-                    url
-                }
             }
             items {
                 sub_nav_link {


### PR DESCRIPTION
Had to  temporarily remove the link {url} query for the primary nav items on desktop has we currently have no primary items with direct links.  Will work with at least 1 entry that requires a direct link.