### PR TITLE
Fixed URLs for apply buttons

### DIFF
--- a/src/components/Navbar/Desktop/DesktopMenu.js
+++ b/src/components/Navbar/Desktop/DesktopMenu.js
@@ -96,7 +96,7 @@ function DesktopMenu(props) {
             <Ul>
                 {navItems}
                 <ButtonContainer>
-                    <Link to={buttonLink}>
+                    <Link to={"/apply"}>
                         <ApplyButton buttonStyle="primary-dark" buttonSize="sm">
                             {buttonText}
                         </ApplyButton>

--- a/src/components/home/HeroHeader.js
+++ b/src/components/home/HeroHeader.js
@@ -114,22 +114,22 @@ function HeroHeader(props) {
     const { title, sub, invite, link, btnText } = props
 
     return (
-            <Container>
-                <FlexContainer>
-                    <H1>{title}</H1>
-                </FlexContainer>
-                <FlexContainer>
-                    <P>{sub}</P>
-                </FlexContainer>
-                <H6>{invite}</H6>
-                <FlexContainer>
-                    <Link to={link}>
-                        <StyledButton buttonStyle="primary-dark">
-                            {btnText}
-                        </StyledButton>
-                    </Link>
-                </FlexContainer>
-            </Container>
+        <Container>
+            <FlexContainer>
+                <H1>{title}</H1>
+            </FlexContainer>
+            <FlexContainer>
+                <P>{sub}</P>
+            </FlexContainer>
+            <H6>{invite}</H6>
+            <FlexContainer>
+                <Link to="/apply">
+                    <StyledButton buttonStyle="primary-dark">
+                        {btnText}
+                    </StyledButton>
+                </Link>
+            </FlexContainer>
+        </Container>
     )
 }
 

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -1,39 +1,40 @@
-import React, {useState} from "react"
+import React, { useState } from "react"
 import Seo from "../components/seo"
 import Layout from "../components/layout.js"
 import SyllabusDownload from "../components/shared/SyllabusDownload"
-import Calendly from '../components/shared/Calendly'
-import SimpleNav from "../components/scholarships/application/SimpleNav";
-import Scheduled from '../components/shared/Scheduled'
+import Calendly from "../components/shared/Calendly"
+import SimpleNav from "../components/scholarships/application/SimpleNav"
+import Scheduled from "../components/shared/Scheduled"
 import { useEffect } from "react"
 
 export default function DownloadSyllabus() {
     const [submitted, setSubmitted] = useState(false)
 
     useEffect(() => {
-        localStorage.getItem('applied') && setSubmitted(true)
+        localStorage.getItem("applied") && setSubmitted(true)
     }, [])
 
     const submit = () => {
-        localStorage.setItem('applied', true)
+        localStorage.setItem("applied", true)
         setSubmitted(true)
     }
 
     return (
         <>
-        {submitted ?
-            <Layout>
-                    <Seo title={"Apply for V School"} />
+            {submitted ? (
+                <Layout>
+                    <Seo title={"Thanks for applying!"} />
                     <Scheduled />
                     <SyllabusDownload />
-            </Layout>
-            :
-            <>
-                <SimpleNav />
-                <Seo title={"Apply for V School"} />
-                <Calendly submit={submit} link="#" />
-                <SyllabusDownload />
-            </>}
+                </Layout>
+            ) : (
+                <>
+                    <SimpleNav />
+                    <Seo title={"Apply for V School"} />
+                    <Calendly submit={submit} link="#" />
+                    <SyllabusDownload />
+                </>
+            )}
         </>
     )
 }


### PR DESCRIPTION
The apply buttons were pointing to the live version of vschool.io/apply instead of just /apply. This meant whenever clicking them (even on local host) they would take you to the live site instead. My guess is because of this, no matter what changes you made to the apply page, they wouldn't show up unless you manually navigated to the /apply page. I tried through ngrok locally and accessed it on mobile safari and it was working, so I'm going to try with the deploy preview next before pushing live.